### PR TITLE
fix(Payload/crc16): preserva 'leading zeros' na geração do CRC16

### DIFF
--- a/src/Payload.php
+++ b/src/Payload.php
@@ -337,7 +337,7 @@ class Payload
         }
 
         //RETORNA CÓDIGO CRC16 DE 4 CARACTERES
-        return self::ID_CRC16 . '04' . strtoupper(dechex($resultado));
+        return self::ID_CRC16 . '04' . strtoupper(sprintf('%04x', $resultado));
     }
 
     /**


### PR DESCRIPTION
A função `dechex` ignora os _leading zeros_ ao realizar a conversão, resultando em códigos pix inválidos nos (raros) casos em que isso acontece.

**Resultado esperado**: 0F00
**Resultado retornado**: F00

A solução é utilizar o `sprintf`, que não possui esse comportamento.

Caso precise algum ajuste, estou à disposição. :smile: 